### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - stage: test
       language: python
       python:
-        - "3.4"
+        # - "3.4" Build fails on Version 3.4 because PyYAML requires version >= 3.5
         - "3.5"
         - "3.6"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mlbench: Distributed Machine Learning Benchmark Helm Chart
 ==========================================================
 
-[![Build Status](https://travis-ci.com/mlbench/mlbench-dashboard.svg?branch=develop)](https://travis-ci.com/mlbench/mlbench-helm)
+[![Build Status](https://travis-ci.com/mlbench/mlbench-dashboard.svg?branch=develop)](https://travis-ci.com/mlbench/mlbench-dashboard)
 [![DocumentationStatus](https://readthedocs.org/projects/mlbench-docs/badge/?version=latest)](https://mlbench.readthedocs.io/projects/mlbench_dashboard/en/latest/readme.html?badge=latest)
 
 MLBench is a Benchmarking Framework for Distributed Machine Learning algorithms.

--- a/src/api/tests/test_api.py
+++ b/src/api/tests/test_api.py
@@ -46,6 +46,7 @@ class ModelRunTests(APITestCase):
                     'custom_image_name': 'mlbench/mlbench_worker',
                     'custom_image_command': 'sleep',
                     'custom_image_all_nodes': True,
-                    'light_target': True},
+                    'light_target': True,
+                    'gpu_enabled': 'false'},
                 format='json')
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
Fixes the failing continuous integration:
- Build used to fail on `python3.4` because of dependency issues.
- Corrected the link in the README.md
- Fixed failing test because of missing `gpu_enabled` attribute in request