### PR TITLE
Add GNMT image

### DIFF
--- a/src/master/settings.py
+++ b/src/master/settings.py
@@ -161,6 +161,11 @@ MLBENCH_IMAGES = {
         "/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend {backend}",
         True,
     ),
+    "mlbench/pytorch-wmt14-gnmt:latest": (
+        "PyTorch Machine Translation GNMT",
+        "/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend {backend}",
+        True,
+    ),
     "mlbench/tensorflow-cifar10-resnet:latest": (
         "Tensorflow Cifar-10 ResNet-20",
         "/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend {backend}",

--- a/src/master/settings_production.py
+++ b/src/master/settings_production.py
@@ -165,6 +165,11 @@ MLBENCH_IMAGES = {
         "/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend {backend}",
         True,
     ),
+    "mlbench/pytorch-wmt14-gnmt:latest": (
+        "PyTorch Machine Translation GNMT",
+        "/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend {backend}",
+        True,
+    ),
     "mlbench/tensorflow-cifar10-resnet:latest": (
         "Tensorflow Cifar-10 ResNet-20",
         "/conda/bin/python /codes/main.py --run_id {run_id} --rank {rank} --hosts {hosts} --backend {backend}",


### PR DESCRIPTION
Adds the GNMT image to the list of benchmark tasks.

Might need change in the future as some problems were encountered with MPI. see [here](https://github.com/mlbench/mlbench-benchmarks/pull/32)