### PR TITLE
Serialize num_workers when returning ModelRun

### DIFF
--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -19,6 +19,7 @@ class ModelRunSerializer(serializers.HyperlinkedModelSerializer):
             "state",
             "job_id",
             "job_metadata",
+            "num_workers",
         ]
 
 


### PR DESCRIPTION
Also returns the `num_workers` field when serializing `ModelRun` data